### PR TITLE
fix: Reset RectTransform offsets for UI Providers on creation

### DIFF
--- a/Editor/Scripts/ContextMenu/GameObjectContextMenu.cs
+++ b/Editor/Scripts/ContextMenu/GameObjectContextMenu.cs
@@ -44,7 +44,7 @@ namespace Limitex.MonoUI.Editor.ContextMenu
         #endregion
 
         #region Utility Methods
-        private static GameObject SpawnPrefab(string path, Transform parent = null)
+        private static GameObject SpawnPrefab(string path, Transform parent = null, bool resetOffset = false)
         {
             var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path);
             if (prefab == null)
@@ -70,21 +70,31 @@ namespace Limitex.MonoUI.Editor.ContextMenu
             instance.transform.localRotation = Quaternion.identity;
             instance.transform.localScale = originalScale;
 
+            if (resetOffset)
+            {
+                RectTransform rectTransform = instance.GetComponent<RectTransform>();
+                if (rectTransform != null)
+                {
+                    rectTransform.offsetMax = Vector2.zero;
+                    rectTransform.offsetMin = Vector2.zero;
+                }
+            }
+
             Undo.RegisterCreatedObjectUndo(instance, $"Create {instance.name}");
             Selection.activeGameObject = instance;
 
             return instance;
         }
 
-        private static GameObject SpawnPrefabWithCanvas(string path, bool forceUnderCanvas = false)
+        private static GameObject SpawnPrefabWithCanvas(string path, bool forceUnderCanvas = false, bool resetOffset = false)
         {
             Canvas canvas = Selection.activeTransform?.GetComponentInParent<Canvas>();
 
             if (canvas != null)
-                return SpawnPrefab(path, forceUnderCanvas ? canvas.transform : null);
+                return SpawnPrefab(path, forceUnderCanvas ? canvas.transform : null, resetOffset);
 
             GameObject canvasObject = SpawnPrefab(PREFAB_ROOT + "Layout/Canvas.prefab");
-            return SpawnPrefab(path, canvasObject.transform);
+            return SpawnPrefab(path, canvasObject.transform, resetOffset);
         }
         #endregion
 
@@ -252,13 +262,13 @@ namespace Limitex.MonoUI.Editor.ContextMenu
 
         #region Provider Menu Items
         [MenuItem(MENU_PROVIDER + "Dialog", false, PROVIDER_PRIORITY)]
-        private static void CreateProvider() => SpawnPrefabWithCanvas(PREFAB_ROOT + "Providers/Dialog Provider.prefab", true);
+        private static void CreateProvider() => SpawnPrefabWithCanvas(PREFAB_ROOT + "Providers/Dialog Provider.prefab", true, true);
 
         [MenuItem(MENU_PROVIDER + "Dialog (bool)", false, PROVIDER_PRIORITY + 1)]
-        private static void CreateProviderBool() => SpawnPrefabWithCanvas(PREFAB_ROOT + "Providers/Dialog Provider (bool).prefab", true);
+        private static void CreateProviderBool() => SpawnPrefabWithCanvas(PREFAB_ROOT + "Providers/Dialog Provider (bool).prefab", true, true);
 
         [MenuItem(MENU_PROVIDER + "Toast", false, PROVIDER_PRIORITY + 2)]
-        private static void CreateToast() => SpawnPrefabWithCanvas(PREFAB_ROOT + "Providers/Toast Provider.prefab", true);
+        private static void CreateToast() => SpawnPrefabWithCanvas(PREFAB_ROOT + "Providers/Toast Provider.prefab", true, true);
         #endregion
 
         #region Credit


### PR DESCRIPTION
This PR addresses an issue where UI Providers (Dialog, Toast) created from the context menu might not have their `RectTransform` offsets (`offsetMin`, `offsetMax`) properly reset to zero. This could lead to them appearing with unexpected positioning if the source prefab had non-zero offsets.

**Changes:**

* Modified `SpawnPrefab` to accept an optional `resetOffset` boolean parameter.
    * If `resetOffset` is `true` and the instantiated GameObject has a `RectTransform` component, its `offsetMin` and `offsetMax` are set to `Vector2.zero`.
* Updated `SpawnPrefabWithCanvas` to accept and pass the `resetOffset` parameter to `SpawnPrefab`.
* The context menu items for creating "Dialog Provider", "Dialog Provider (bool)", and "Toast Provider" now call `SpawnPrefabWithCanvas` with `resetOffset` set to `true`.

This ensures that these UI elements are initialized with a clean transform state, typically causing them to correctly fill their parent `RectTransform` or align as intended by their anchors without initial offsets.