### PR TITLE
feat: Implement Object Toggles and Buttons

### DIFF
--- a/Editor/Scripts/Build/ObjectToggleBuildProcessor.cs
+++ b/Editor/Scripts/Build/ObjectToggleBuildProcessor.cs
@@ -1,0 +1,98 @@
+#if UNITY_EDITOR
+
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using System.Collections.Generic;
+using System.Linq;
+using VRC.Udon;
+using Limitex.MonoUI.Editor.Utils;
+using Limitex.MonoUI.Udon;
+
+class ObjectToggleBuildProcessor : IProcessSceneWithReport
+{
+    public int callbackOrder => 0;
+
+    public void OnProcessScene(Scene scene, BuildReport report)
+    {
+        ProcessSceneToggles(scene);
+    }
+
+    #region Main Processing Logic
+
+    private void ProcessSceneToggles(Scene scene)
+    {
+        var objectToggles = FindComponentsInScene<ObjectToggle>(scene);
+        var objectToggleTriggers = FindComponentsInScene<ObjectToggleTrigger>(scene);
+
+        var links = BuildLinkMap(objectToggles, objectToggleTriggers);
+
+        ApplyLinks(links);
+    }
+
+    #endregion
+
+    #region Type-Safe Helper Methods
+
+    private List<T> FindComponentsInScene<T>(Scene scene) where T : Component
+    {
+        var foundComponents = new List<T>();
+        foreach (var rootGo in scene.GetRootGameObjects())
+        {
+            using (var finder = new HierarchyComponentFinder<T>(includeInactive: true, parent: rootGo.transform))
+            {
+                foundComponents.AddRange(finder);
+            }
+        }
+        return foundComponents;
+    }
+
+    private Dictionary<ObjectToggle, List<ObjectToggleTrigger>> BuildLinkMap(List<ObjectToggle> toggles, List<ObjectToggleTrigger> triggers)
+    {
+        var linkMap = new Dictionary<ObjectToggle, List<ObjectToggleTrigger>>();
+
+        foreach (var ot in toggles)
+        {
+            linkMap[ot] = new List<ObjectToggleTrigger>();
+        }
+
+        foreach (var trigger in triggers)
+        {
+            var targetObjectToggle = (ObjectToggle)trigger.GetProgramVariable(nameof(ObjectToggleTrigger._targetObjectToggle));
+
+            if (targetObjectToggle != null && linkMap.ContainsKey(targetObjectToggle))
+            {
+                linkMap[targetObjectToggle].Add(trigger);
+            }
+        }
+        return linkMap;
+    }
+
+    private void ApplyLinks(Dictionary<ObjectToggle, List<ObjectToggleTrigger>> links)
+    {
+        if (links.Count == 0)
+        {
+            return;
+        }
+
+        int totalLinks = 0;
+        foreach (var pair in links)
+        {
+            ObjectToggle objectToggle = pair.Key;
+
+            List<ObjectToggleTrigger> togglesToLink = pair.Value;
+
+            if (togglesToLink.Count > 0)
+            {
+                objectToggle.SetProgramVariable(nameof(ObjectToggle._linkedToggles), togglesToLink.ToArray());
+                totalLinks += togglesToLink.Count;
+            }
+        }
+    }
+
+    #endregion
+}
+
+#endif

--- a/Editor/Scripts/Build/ObjectToggleBuildProcessor.cs
+++ b/Editor/Scripts/Build/ObjectToggleBuildProcessor.cs
@@ -60,7 +60,7 @@ class ObjectToggleBuildProcessor : IProcessSceneWithReport
 
         foreach (var trigger in triggers)
         {
-            var targetObjectToggle = (ObjectToggle)trigger.GetProgramVariable(nameof(ObjectToggleTrigger._targetObjectToggle));
+            var targetObjectToggle = (ObjectToggle)trigger.GetProgramVariable(ObjectToggleTrigger.TargetObjectToggleName);
 
             if (targetObjectToggle != null && linkMap.ContainsKey(targetObjectToggle))
             {
@@ -86,7 +86,7 @@ class ObjectToggleBuildProcessor : IProcessSceneWithReport
 
             if (togglesToLink.Count > 0)
             {
-                objectToggle.SetProgramVariable(nameof(ObjectToggle._linkedToggles), togglesToLink.ToArray());
+                objectToggle.SetProgramVariable(ObjectToggle.LinkedTogglesName, togglesToLink.ToArray());
                 totalLinks += togglesToLink.Count;
             }
         }

--- a/Editor/Scripts/Build/ObjectToggleBuildProcessor.cs
+++ b/Editor/Scripts/Build/ObjectToggleBuildProcessor.cs
@@ -11,88 +11,91 @@ using VRC.Udon;
 using Limitex.MonoUI.Editor.Utils;
 using Limitex.MonoUI.Udon;
 
-class ObjectToggleBuildProcessor : IProcessSceneWithReport
+namespace Limitex.MonoUI.Editor.Build
 {
-    public int callbackOrder => 0;
-
-    public void OnProcessScene(Scene scene, BuildReport report)
+    public class ObjectToggleBuildProcessor : IProcessSceneWithReport
     {
-        ProcessSceneToggles(scene);
-    }
+        public int callbackOrder => 0;
 
-    #region Main Processing Logic
-
-    private void ProcessSceneToggles(Scene scene)
-    {
-        var objectToggles = FindComponentsInScene<ObjectToggle>(scene);
-        var objectToggleTriggers = FindComponentsInScene<ObjectToggleTrigger>(scene);
-
-        var links = BuildLinkMap(objectToggles, objectToggleTriggers);
-
-        ApplyLinks(links);
-    }
-
-    #endregion
-
-    #region Type-Safe Helper Methods
-
-    private List<T> FindComponentsInScene<T>(Scene scene) where T : Component
-    {
-        var foundComponents = new List<T>();
-        foreach (var rootGo in scene.GetRootGameObjects())
+        public void OnProcessScene(Scene scene, BuildReport report)
         {
-            using (var finder = new HierarchyComponentFinder<T>(includeInactive: true, parent: rootGo.transform))
+            ProcessSceneToggles(scene);
+        }
+
+        #region Main Processing Logic
+
+        private void ProcessSceneToggles(Scene scene)
+        {
+            var objectToggles = FindComponentsInScene<ObjectToggle>(scene);
+            var objectToggleTriggers = FindComponentsInScene<ObjectToggleTrigger>(scene);
+
+            var links = BuildLinkMap(objectToggles, objectToggleTriggers);
+
+            ApplyLinks(links);
+        }
+
+        #endregion
+
+        #region Type-Safe Helper Methods
+
+        private List<T> FindComponentsInScene<T>(Scene scene) where T : Component
+        {
+            var foundComponents = new List<T>();
+            foreach (var rootGo in scene.GetRootGameObjects())
             {
-                foundComponents.AddRange(finder);
+                using (var finder = new HierarchyComponentFinder<T>(includeInactive: true, parent: rootGo.transform))
+                {
+                    foundComponents.AddRange(finder);
+                }
+            }
+            return foundComponents;
+        }
+
+        private Dictionary<ObjectToggle, List<ObjectToggleTrigger>> BuildLinkMap(List<ObjectToggle> toggles, List<ObjectToggleTrigger> triggers)
+        {
+            var linkMap = new Dictionary<ObjectToggle, List<ObjectToggleTrigger>>();
+
+            foreach (var ot in toggles)
+            {
+                linkMap[ot] = new List<ObjectToggleTrigger>();
+            }
+
+            foreach (var trigger in triggers)
+            {
+                var targetObjectToggle = (ObjectToggle)trigger.GetProgramVariable(ObjectToggleTrigger.TargetObjectToggleName);
+
+                if (targetObjectToggle != null && linkMap.ContainsKey(targetObjectToggle))
+                {
+                    linkMap[targetObjectToggle].Add(trigger);
+                }
+            }
+            return linkMap;
+        }
+
+        private void ApplyLinks(Dictionary<ObjectToggle, List<ObjectToggleTrigger>> links)
+        {
+            if (links.Count == 0)
+            {
+                return;
+            }
+
+            int totalLinks = 0;
+            foreach (var pair in links)
+            {
+                ObjectToggle objectToggle = pair.Key;
+
+                List<ObjectToggleTrigger> togglesToLink = pair.Value;
+
+                if (togglesToLink.Count > 0)
+                {
+                    objectToggle.SetProgramVariable(ObjectToggle.LinkedTogglesName, togglesToLink.ToArray());
+                    totalLinks += togglesToLink.Count;
+                }
             }
         }
-        return foundComponents;
+
+        #endregion
     }
-
-    private Dictionary<ObjectToggle, List<ObjectToggleTrigger>> BuildLinkMap(List<ObjectToggle> toggles, List<ObjectToggleTrigger> triggers)
-    {
-        var linkMap = new Dictionary<ObjectToggle, List<ObjectToggleTrigger>>();
-
-        foreach (var ot in toggles)
-        {
-            linkMap[ot] = new List<ObjectToggleTrigger>();
-        }
-
-        foreach (var trigger in triggers)
-        {
-            var targetObjectToggle = (ObjectToggle)trigger.GetProgramVariable(ObjectToggleTrigger.TargetObjectToggleName);
-
-            if (targetObjectToggle != null && linkMap.ContainsKey(targetObjectToggle))
-            {
-                linkMap[targetObjectToggle].Add(trigger);
-            }
-        }
-        return linkMap;
-    }
-
-    private void ApplyLinks(Dictionary<ObjectToggle, List<ObjectToggleTrigger>> links)
-    {
-        if (links.Count == 0)
-        {
-            return;
-        }
-
-        int totalLinks = 0;
-        foreach (var pair in links)
-        {
-            ObjectToggle objectToggle = pair.Key;
-
-            List<ObjectToggleTrigger> togglesToLink = pair.Value;
-
-            if (togglesToLink.Count > 0)
-            {
-                objectToggle.SetProgramVariable(ObjectToggle.LinkedTogglesName, togglesToLink.ToArray());
-                totalLinks += togglesToLink.Count;
-            }
-        }
-    }
-
-    #endregion
 }
 
 #endif

--- a/Editor/Scripts/Build/ObjectToggleBuildProcessor.cs.meta
+++ b/Editor/Scripts/Build/ObjectToggleBuildProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23da25d39d785fc41a3d7dbc90bcf5ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Scripts/Inspector/ObjectButtonEditor.cs
+++ b/Editor/Scripts/Inspector/ObjectButtonEditor.cs
@@ -21,7 +21,7 @@ namespace Limitex.MonoUI.Editor.Inspector
             ReferencedByDrawer.Draw<ObjectButton, ObjectButtonTrigger>(
                 ref showReferencedBy,
                 (ObjectButton)target,
-                nameof(ObjectButtonTrigger._targetObjectButton));
+                ObjectButtonTrigger.TargetObjectButtonName);
         }
     }
 }

--- a/Editor/Scripts/Inspector/ObjectButtonEditor.cs
+++ b/Editor/Scripts/Inspector/ObjectButtonEditor.cs
@@ -2,7 +2,6 @@
 
 using UnityEngine;
 using UnityEditor;
-using System.Collections.Generic;
 using Limitex.MonoUI.Udon;
 using Limitex.MonoUI.Editor.Utils;
 
@@ -11,7 +10,6 @@ namespace Limitex.MonoUI.Editor.Inspector
     [CustomEditor(typeof(ObjectButton))]
     public class ObjectButtonEditor : UnityEditor.Editor
     {
-        private const string targetFieldName = "_targetObjectButton";
         private static bool showReferencedBy = true;
 
         public override void OnInspectorGUI()
@@ -20,79 +18,11 @@ namespace Limitex.MonoUI.Editor.Inspector
 
             EditorGUILayout.Space(10);
 
-            showReferencedBy = EditorGUILayout.Foldout(showReferencedBy, "Referenced By (Detected in Scene)", true, EditorStyles.foldoutHeader);
-
-            if (showReferencedBy)
-            {
-                DrawReferencedByList();
-            }
+            ReferencedByDrawer.Draw<ObjectButton, ObjectButtonTrigger>(
+                ref showReferencedBy,
+                (ObjectButton)target,
+                nameof(ObjectButtonTrigger._targetObjectButton));
         }
-
-        #region Draw Methods
-
-        private void DrawReferencedByList()
-        {
-            var currentObjectButton = (ObjectButton)target;
-
-            List<MonoUIBehaviour> foundTriggers = FindReferencesInScene(currentObjectButton);
-
-            EditorGUI.indentLevel++;
-
-            if (foundTriggers.Count > 0)
-            {
-                foreach (var trigger in foundTriggers)
-                {
-                    if (trigger == null) continue;
-                    DrawReferenceRow(trigger);
-                }
-            }
-            else
-            {
-                EditorGUILayout.LabelField("None");
-            }
-
-            EditorGUI.indentLevel--;
-        }
-
-        private void DrawReferenceRow(MonoUIBehaviour trigger)
-        {
-            EditorGUILayout.BeginHorizontal();
-            EditorGUILayout.LabelField(trigger.gameObject.name);
-            EditorGUILayout.ObjectField(trigger.gameObject, typeof(GameObject), true);
-            EditorGUILayout.EndHorizontal();
-        }
-
-        #endregion
-
-        #region Helper Methods
-
-        private List<MonoUIBehaviour> FindReferencesInScene(ObjectButton targetButton)
-        {
-            var references = new List<MonoUIBehaviour>();
-
-            FindAndAddReferences<ObjectButtonTrigger>(targetButton, references);
-
-            return references;
-        }
-
-        private void FindAndAddReferences<T>(ObjectButton targetButton, List<MonoUIBehaviour> references) where T : MonoUIBehaviour
-        {
-            using (var finder = new HierarchyComponentFinder<T>(includeInactive: true))
-            {
-                foreach (var trigger in finder)
-                {
-                    var serializedTrigger = new SerializedObject(trigger);
-                    var targetProperty = serializedTrigger.FindProperty(targetFieldName);
-
-                    if (targetProperty != null && targetProperty.objectReferenceValue == targetButton)
-                    {
-                        references.Add(trigger);
-                    }
-                }
-            }
-        }
-
-        #endregion
     }
 }
 

--- a/Editor/Scripts/Inspector/ObjectButtonEditor.cs
+++ b/Editor/Scripts/Inspector/ObjectButtonEditor.cs
@@ -1,0 +1,99 @@
+#if UNITY_EDITOR
+
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+using Limitex.MonoUI.Udon;
+using Limitex.MonoUI.Editor.Utils;
+
+namespace Limitex.MonoUI.Editor.Inspector
+{
+    [CustomEditor(typeof(ObjectButton))]
+    public class ObjectButtonEditor : UnityEditor.Editor
+    {
+        private const string targetFieldName = "_targetObjectButton";
+        private static bool showReferencedBy = true;
+
+        public override void OnInspectorGUI()
+        {
+            DrawDefaultInspector();
+
+            EditorGUILayout.Space(10);
+
+            showReferencedBy = EditorGUILayout.Foldout(showReferencedBy, "Referenced By (Detected in Scene)", true, EditorStyles.foldoutHeader);
+
+            if (showReferencedBy)
+            {
+                DrawReferencedByList();
+            }
+        }
+
+        #region Draw Methods
+
+        private void DrawReferencedByList()
+        {
+            var currentObjectButton = (ObjectButton)target;
+
+            List<MonoUIBehaviour> foundTriggers = FindReferencesInScene(currentObjectButton);
+
+            EditorGUI.indentLevel++;
+
+            if (foundTriggers.Count > 0)
+            {
+                foreach (var trigger in foundTriggers)
+                {
+                    if (trigger == null) continue;
+                    DrawReferenceRow(trigger);
+                }
+            }
+            else
+            {
+                EditorGUILayout.LabelField("None");
+            }
+
+            EditorGUI.indentLevel--;
+        }
+
+        private void DrawReferenceRow(MonoUIBehaviour trigger)
+        {
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField(trigger.gameObject.name);
+            EditorGUILayout.ObjectField(trigger.gameObject, typeof(GameObject), true);
+            EditorGUILayout.EndHorizontal();
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private List<MonoUIBehaviour> FindReferencesInScene(ObjectButton targetButton)
+        {
+            var references = new List<MonoUIBehaviour>();
+
+            FindAndAddReferences<ObjectButtonTrigger>(targetButton, references);
+
+            return references;
+        }
+
+        private void FindAndAddReferences<T>(ObjectButton targetButton, List<MonoUIBehaviour> references) where T : MonoUIBehaviour
+        {
+            using (var finder = new HierarchyComponentFinder<T>(includeInactive: true))
+            {
+                foreach (var trigger in finder)
+                {
+                    var serializedTrigger = new SerializedObject(trigger);
+                    var targetProperty = serializedTrigger.FindProperty(targetFieldName);
+
+                    if (targetProperty != null && targetProperty.objectReferenceValue == targetButton)
+                    {
+                        references.Add(trigger);
+                    }
+                }
+            }
+        }
+
+        #endregion
+    }
+}
+
+#endif

--- a/Editor/Scripts/Inspector/ObjectButtonEditor.cs.meta
+++ b/Editor/Scripts/Inspector/ObjectButtonEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04edd5aa9e541f343bca22faeedf7b97
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Scripts/Inspector/ObjectToggleEditor.cs
+++ b/Editor/Scripts/Inspector/ObjectToggleEditor.cs
@@ -21,7 +21,7 @@ namespace Limitex.MonoUI.Editor.Inspector
             ReferencedByDrawer.Draw<ObjectToggle, ObjectToggleTrigger>(
                 ref showReferencedBy,
                 (ObjectToggle)target,
-                nameof(ObjectToggleTrigger._targetObjectToggle));
+                ObjectToggleTrigger.TargetObjectToggleName);
         }
     }
 }

--- a/Editor/Scripts/Inspector/ObjectToggleEditor.cs
+++ b/Editor/Scripts/Inspector/ObjectToggleEditor.cs
@@ -2,7 +2,6 @@
 
 using UnityEngine;
 using UnityEditor;
-using System.Collections.Generic;
 using Limitex.MonoUI.Udon;
 using Limitex.MonoUI.Editor.Utils;
 
@@ -19,79 +18,11 @@ namespace Limitex.MonoUI.Editor.Inspector
 
             EditorGUILayout.Space(10);
 
-            showReferencedBy = EditorGUILayout.Foldout(showReferencedBy, "Referenced By (Detected in Scene)", true, EditorStyles.foldoutHeader);
-
-            if (showReferencedBy)
-            {
-                DrawReferencedByList();
-            }
+            ReferencedByDrawer.Draw<ObjectToggle, ObjectToggleTrigger>(
+                ref showReferencedBy,
+                (ObjectToggle)target,
+                nameof(ObjectToggleTrigger._targetObjectToggle));
         }
-
-        #region Draw Methods
-
-        private void DrawReferencedByList()
-        {
-            var currentObjectToggle = (ObjectToggle)target;
-
-            List<MonoUIBehaviour> foundTriggers = FindReferencesInScene(currentObjectToggle);
-
-            EditorGUI.indentLevel++;
-
-            if (foundTriggers.Count > 0)
-            {
-                foreach (var trigger in foundTriggers)
-                {
-                    if (trigger == null) continue;
-                    DrawReferenceRow(trigger);
-                }
-            }
-            else
-            {
-                EditorGUILayout.LabelField("None");
-            }
-
-            EditorGUI.indentLevel--;
-        }
-
-        private void DrawReferenceRow(MonoUIBehaviour trigger)
-        {
-            EditorGUILayout.BeginHorizontal();
-            EditorGUILayout.LabelField(trigger.gameObject.name);
-            EditorGUILayout.ObjectField(trigger.gameObject, typeof(GameObject), true);
-            EditorGUILayout.EndHorizontal();
-        }
-
-        #endregion
-
-        #region Helper Methods
-
-        private List<MonoUIBehaviour> FindReferencesInScene(ObjectToggle targetToggle)
-        {
-            var references = new List<MonoUIBehaviour>();
-
-            FindAndAddReferences<ObjectToggleTrigger>(targetToggle, references);
-
-            return references;
-        }
-
-        private void FindAndAddReferences<T>(ObjectToggle targetToggle, List<MonoUIBehaviour> references) where T : MonoUIBehaviour
-        {
-            using (var finder = new HierarchyComponentFinder<T>(includeInactive: true))
-            {
-                foreach (var trigger in finder)
-                {
-                    var serializedTrigger = new SerializedObject(trigger);
-                    var targetProperty = serializedTrigger.FindProperty(nameof(ObjectToggleTrigger._targetObjectToggle));
-
-                    if (targetProperty != null && targetProperty.objectReferenceValue == targetToggle)
-                    {
-                        references.Add(trigger);
-                    }
-                }
-            }
-        }
-
-        #endregion
     }
 }
 

--- a/Editor/Scripts/Inspector/ObjectToggleEditor.cs
+++ b/Editor/Scripts/Inspector/ObjectToggleEditor.cs
@@ -1,0 +1,98 @@
+#if UNITY_EDITOR
+
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+using Limitex.MonoUI.Udon;
+using Limitex.MonoUI.Editor.Utils;
+
+namespace Limitex.MonoUI.Editor.Inspector
+{
+    [CustomEditor(typeof(ObjectToggle))]
+    public class ObjectToggleEditor : UnityEditor.Editor
+    {
+        private static bool showReferencedBy = true;
+
+        public override void OnInspectorGUI()
+        {
+            DrawDefaultInspector();
+
+            EditorGUILayout.Space(10);
+
+            showReferencedBy = EditorGUILayout.Foldout(showReferencedBy, "Referenced By (Detected in Scene)", true, EditorStyles.foldoutHeader);
+
+            if (showReferencedBy)
+            {
+                DrawReferencedByList();
+            }
+        }
+
+        #region Draw Methods
+
+        private void DrawReferencedByList()
+        {
+            var currentObjectToggle = (ObjectToggle)target;
+
+            List<MonoUIBehaviour> foundTriggers = FindReferencesInScene(currentObjectToggle);
+
+            EditorGUI.indentLevel++;
+
+            if (foundTriggers.Count > 0)
+            {
+                foreach (var trigger in foundTriggers)
+                {
+                    if (trigger == null) continue;
+                    DrawReferenceRow(trigger);
+                }
+            }
+            else
+            {
+                EditorGUILayout.LabelField("None");
+            }
+
+            EditorGUI.indentLevel--;
+        }
+
+        private void DrawReferenceRow(MonoUIBehaviour trigger)
+        {
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField(trigger.gameObject.name);
+            EditorGUILayout.ObjectField(trigger.gameObject, typeof(GameObject), true);
+            EditorGUILayout.EndHorizontal();
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private List<MonoUIBehaviour> FindReferencesInScene(ObjectToggle targetToggle)
+        {
+            var references = new List<MonoUIBehaviour>();
+
+            FindAndAddReferences<ObjectToggleTrigger>(targetToggle, references);
+
+            return references;
+        }
+
+        private void FindAndAddReferences<T>(ObjectToggle targetToggle, List<MonoUIBehaviour> references) where T : MonoUIBehaviour
+        {
+            using (var finder = new HierarchyComponentFinder<T>(includeInactive: true))
+            {
+                foreach (var trigger in finder)
+                {
+                    var serializedTrigger = new SerializedObject(trigger);
+                    var targetProperty = serializedTrigger.FindProperty(nameof(ObjectToggleTrigger._targetObjectToggle));
+
+                    if (targetProperty != null && targetProperty.objectReferenceValue == targetToggle)
+                    {
+                        references.Add(trigger);
+                    }
+                }
+            }
+        }
+
+        #endregion
+    }
+}
+
+#endif

--- a/Editor/Scripts/Inspector/ObjectToggleEditor.cs.meta
+++ b/Editor/Scripts/Inspector/ObjectToggleEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6963a17859f751439a72e2f3d9840ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Scripts/Utils/ReferencedByDrawer.cs
+++ b/Editor/Scripts/Utils/ReferencedByDrawer.cs
@@ -1,0 +1,76 @@
+#if UNITY_EDITOR
+
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+using Limitex.MonoUI.Editor.Utils;
+
+namespace Limitex.MonoUI.Editor.Utils
+{
+    public static class ReferencedByDrawer
+    {
+        public static void Draw<TTarget, TTrigger>(ref bool foldoutState, TTarget targetObject, string referenceFieldName)
+            where TTarget : Component
+            where TTrigger : Component
+        {
+            foldoutState = EditorGUILayout.Foldout(foldoutState, "Referenced By (Detected in Scene)", true, EditorStyles.foldoutHeader);
+            if (!foldoutState) return;
+            List<TTrigger> references = FindReferences<TTarget, TTrigger>(targetObject, referenceFieldName);
+
+            DrawReferenceList(references);
+        }
+
+        private static void DrawReferenceList<T>(List<T> references) where T : Component
+        {
+            EditorGUI.indentLevel++;
+
+            if (references.Count > 0)
+            {
+                foreach (var trigger in references)
+                {
+                    if (trigger == null) continue;
+                    DrawReferenceRow(trigger);
+                }
+            }
+            else
+            {
+                EditorGUILayout.LabelField("None");
+            }
+
+            EditorGUI.indentLevel--;
+        }
+
+        private static void DrawReferenceRow(Component trigger)
+        {
+            EditorGUILayout.BeginHorizontal();
+            EditorGUI.BeginDisabledGroup(true);
+            EditorGUILayout.ObjectField(trigger.gameObject, typeof(GameObject), true);
+            EditorGUI.EndDisabledGroup();
+            EditorGUILayout.EndHorizontal();
+        }
+
+        private static List<TTrigger> FindReferences<TTarget, TTrigger>(TTarget targetObject, string referenceFieldName)
+            where TTarget : Component
+            where TTrigger : Component
+        {
+            var references = new List<TTrigger>();
+
+            using (var finder = new HierarchyComponentFinder<TTrigger>(includeInactive: true))
+            {
+                foreach (var trigger in finder)
+                {
+                    var serializedTrigger = new SerializedObject(trigger);
+                    var targetProperty = serializedTrigger.FindProperty(referenceFieldName);
+
+                    if (targetProperty != null && targetProperty.objectReferenceValue == targetObject)
+                    {
+                        references.Add(trigger);
+                    }
+                }
+            }
+            return references;
+        }
+    }
+}
+
+#endif

--- a/Editor/Scripts/Utils/ReferencedByDrawer.cs.meta
+++ b/Editor/Scripts/Utils/ReferencedByDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f6c3aa3bff23ace4da7134617d4041d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Udon/UdonAssets/ObjectButton.asset
+++ b/Runtime/Udon/UdonAssets/ObjectButton.asset
@@ -1,0 +1,821 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
+  m_Name: ObjectButton
+  m_EditorClassIdentifier: 
+  serializedUdonProgramAsset: {fileID: 11400000, guid: 984f81fc4d529774ca12da3c284e4783,
+    type: 2}
+  udonAssembly: 
+  assemblyError: 
+  sourceCsScript: {fileID: 11500000, guid: 5bcc7fabf91247a48ab90924130bc16e, type: 3}
+  scriptVersion: 2
+  compiledVersion: 2
+  behaviourSyncMode: 4
+  hasInteractEvent: 0
+  scriptID: 7491968631277236744
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes:
+    - Name: fieldDefinitions
+      Entry: 7
+      Data: 0|System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[UdonSharp.Compiler.FieldDefinition,
+        UdonSharp.Editor]], mscorlib
+    - Name: comparer
+      Entry: 7
+      Data: 1|System.Collections.Generic.GenericEqualityComparer`1[[System.String,
+        mscorlib]], mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 12
+      Data: 13
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: button
+    - Name: $v
+      Entry: 7
+      Data: 2|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: button
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 3|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.Button, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 3
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 4|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 5|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: toggle
+    - Name: $v
+      Entry: 7
+      Data: 6|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: toggle
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 7|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.Toggle, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 7
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 8|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 9|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: toggleGroup
+    - Name: $v
+      Entry: 7
+      Data: 10|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: toggleGroup
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 11|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.ToggleGroup, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 11
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 12|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 13|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: slider
+    - Name: $v
+      Entry: 7
+      Data: 14|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: slider
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 15|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.Slider, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 15
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 16|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 17|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: scrollbar
+    - Name: $v
+      Entry: 7
+      Data: 18|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: scrollbar
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 19|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.Scrollbar, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 19
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 20|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 21|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: scrollRect
+    - Name: $v
+      Entry: 7
+      Data: 22|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: scrollRect
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 23|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.ScrollRect, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 23
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 24|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 25|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: tmpDropdown
+    - Name: $v
+      Entry: 7
+      Data: 26|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: tmpDropdown
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 27|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: TMPro.TMP_Dropdown, Unity.TextMeshPro
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 27
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 28|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 29|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: tmpInputField
+    - Name: $v
+      Entry: 7
+      Data: 30|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: tmpInputField
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 31|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: TMPro.TMP_InputField, Unity.TextMeshPro
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 31
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 32|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 33|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _isGlobal
+    - Name: $v
+      Entry: 7
+      Data: 34|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _isGlobal
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 35|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Boolean, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 35
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 36|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 37|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _buttonType
+    - Name: $v
+      Entry: 7
+      Data: 38|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _buttonType
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 39|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: Limitex.MonoUI.Udon.ButtonType, dev.limitex.mono-ui.udon
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 7
+      Data: 40|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Int32, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 41|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 42|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _targets
+    - Name: $v
+      Entry: 7
+      Data: 43|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _targets
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 44|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.Transform[], UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 44
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 45|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 46|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _mask
+    - Name: $v
+      Entry: 7
+      Data: 47|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _mask
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 40
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 40
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 3
+      Data: 1
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 48|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 49|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: MaxTargets
+    - Name: $v
+      Entry: 7
+      Data: 50|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: MaxTargets
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 40
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 40
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 51|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 

--- a/Runtime/Udon/UdonAssets/ObjectButton.asset
+++ b/Runtime/Udon/UdonAssets/ObjectButton.asset
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 13
+      Data: 14
     - Name: 
       Entry: 7
       Data: 
@@ -590,16 +590,70 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _buttonType
+      Data: _defaultTargetState
     - Name: $v
       Entry: 7
       Data: 38|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
+      Data: _defaultTargetState
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 35
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 35
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 39|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 40|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _buttonType
+    - Name: $v
+      Entry: 7
+      Data: 41|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
       Data: _buttonType
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 39|System.RuntimeType, mscorlib
+      Data: 42|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: Limitex.MonoUI.Udon.ButtonType, dev.limitex.mono-ui.udon
@@ -608,7 +662,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 7
-      Data: 40|System.RuntimeType, mscorlib
+      Data: 43|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: System.Int32, mscorlib
@@ -629,13 +683,13 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 41|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 44|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 42|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 45|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
@@ -659,13 +713,13 @@ MonoBehaviour:
       Data: _targets
     - Name: $v
       Entry: 7
-      Data: 43|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 46|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: _targets
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 44|System.RuntimeType, mscorlib
+      Data: 47|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: UnityEngine.Transform[], UnityEngine.CoreModule
@@ -674,7 +728,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 44
+      Data: 47
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -689,13 +743,13 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 45|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 48|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 46|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 49|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
@@ -719,16 +773,16 @@ MonoBehaviour:
       Data: _mask
     - Name: $v
       Entry: 7
-      Data: 47|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 50|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: _mask
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 40
+      Data: 43
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 40
+      Data: 43
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -743,13 +797,13 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 48|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 51|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 49|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
+      Data: 52|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
     - Name: 
       Entry: 8
       Data: 
@@ -773,16 +827,16 @@ MonoBehaviour:
       Data: MaxTargets
     - Name: $v
       Entry: 7
-      Data: 50|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 53|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: MaxTargets
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 40
+      Data: 43
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 40
+      Data: 43
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -797,7 +851,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 51|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 54|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0

--- a/Runtime/Udon/UdonAssets/ObjectButton.asset.meta
+++ b/Runtime/Udon/UdonAssets/ObjectButton.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3fc97376dfb6f3849a7edd7fd98ae68d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Udon/UdonAssets/ObjectButtonTrigger.asset
+++ b/Runtime/Udon/UdonAssets/ObjectButtonTrigger.asset
@@ -1,0 +1,599 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
+  m_Name: ObjectButtonTrigger
+  m_EditorClassIdentifier: 
+  serializedUdonProgramAsset: {fileID: 11400000, guid: c705fc4ca4b15884383f2a71d64cf16a,
+    type: 2}
+  udonAssembly: 
+  assemblyError: 
+  sourceCsScript: {fileID: 11500000, guid: 0ed71b4437bf0ae488602f5ec5adcfc8, type: 3}
+  scriptVersion: 2
+  compiledVersion: 2
+  behaviourSyncMode: 4
+  hasInteractEvent: 0
+  scriptID: 8292517663051584640
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes:
+    - Name: fieldDefinitions
+      Entry: 7
+      Data: 0|System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[UdonSharp.Compiler.FieldDefinition,
+        UdonSharp.Editor]], mscorlib
+    - Name: comparer
+      Entry: 7
+      Data: 1|System.Collections.Generic.GenericEqualityComparer`1[[System.String,
+        mscorlib]], mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 12
+      Data: 9
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: button
+    - Name: $v
+      Entry: 7
+      Data: 2|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: button
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 3|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.Button, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 3
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 4|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 5|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: toggle
+    - Name: $v
+      Entry: 7
+      Data: 6|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: toggle
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 7|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.Toggle, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 7
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 8|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 9|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: toggleGroup
+    - Name: $v
+      Entry: 7
+      Data: 10|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: toggleGroup
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 11|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.ToggleGroup, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 11
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 12|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 13|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: slider
+    - Name: $v
+      Entry: 7
+      Data: 14|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: slider
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 15|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.Slider, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 15
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 16|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 17|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: scrollbar
+    - Name: $v
+      Entry: 7
+      Data: 18|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: scrollbar
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 19|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.Scrollbar, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 19
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 20|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 21|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: scrollRect
+    - Name: $v
+      Entry: 7
+      Data: 22|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: scrollRect
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 23|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.ScrollRect, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 23
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 24|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 25|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: tmpDropdown
+    - Name: $v
+      Entry: 7
+      Data: 26|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: tmpDropdown
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 27|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: TMPro.TMP_Dropdown, Unity.TextMeshPro
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 27
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 28|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 29|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: tmpInputField
+    - Name: $v
+      Entry: 7
+      Data: 30|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: tmpInputField
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 31|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: TMPro.TMP_InputField, Unity.TextMeshPro
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 31
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 32|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 33|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _targetObjectButton
+    - Name: $v
+      Entry: 7
+      Data: 34|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _targetObjectButton
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 35|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: Limitex.MonoUI.Udon.ObjectButton, dev.limitex.mono-ui.udon
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 7
+      Data: 36|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: VRC.Udon.UdonBehaviour, VRC.Udon
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 37|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 38|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 

--- a/Runtime/Udon/UdonAssets/ObjectButtonTrigger.asset.meta
+++ b/Runtime/Udon/UdonAssets/ObjectButtonTrigger.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 65e8d49775c6d9e418673a50ee968170
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Udon/UdonAssets/ObjectToggle.asset
+++ b/Runtime/Udon/UdonAssets/ObjectToggle.asset
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 15
+      Data: 16
     - Name: 
       Entry: 7
       Data: 
@@ -906,6 +906,54 @@ MonoBehaviour:
     - Name: _fieldAttributes
       Entry: 7
       Data: 57|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: InitialToggleState
+    - Name: $v
+      Entry: 7
+      Data: 58|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: InitialToggleState
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 35
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 35
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 59|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0

--- a/Runtime/Udon/UdonAssets/ObjectToggle.asset
+++ b/Runtime/Udon/UdonAssets/ObjectToggle.asset
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 14
+      Data: 15
     - Name: 
       Entry: 7
       Data: 
@@ -590,25 +590,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _targets
+      Data: _defaultTargetState
     - Name: $v
       Entry: 7
       Data: 38|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _targets
+      Data: _defaultTargetState
     - Name: <UserType>k__BackingField
-      Entry: 7
-      Data: 39|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: UnityEngine.Transform[], UnityEngine.CoreModule
-    - Name: 
-      Entry: 8
-      Data: 
+      Entry: 9
+      Data: 35
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 39
+      Data: 35
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -623,13 +617,73 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 40|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 39|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 41|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 40|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _targets
+    - Name: $v
+      Entry: 7
+      Data: 41|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _targets
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 42|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.Transform[], UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 42
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 43|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 44|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
@@ -653,13 +707,13 @@ MonoBehaviour:
       Data: _linkedToggles
     - Name: $v
       Entry: 7
-      Data: 42|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 45|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: _linkedToggles
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 43|System.RuntimeType, mscorlib
+      Data: 46|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: Limitex.MonoUI.Udon.ObjectToggleTrigger[], dev.limitex.mono-ui.udon
@@ -668,7 +722,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 7
-      Data: 44|System.RuntimeType, mscorlib
+      Data: 47|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: UnityEngine.Component[], UnityEngine.CoreModule
@@ -689,13 +743,13 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 45|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 48|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 46|UnityEngine.HideInInspector, UnityEngine.CoreModule
+      Data: 49|UnityEngine.HideInInspector, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
@@ -719,7 +773,7 @@ MonoBehaviour:
       Data: _invertMask
     - Name: $v
       Entry: 7
-      Data: 47|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 50|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: _invertMask
@@ -743,13 +797,13 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 48|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 51|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 49|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
+      Data: 52|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
     - Name: 
       Entry: 8
       Data: 
@@ -773,13 +827,13 @@ MonoBehaviour:
       Data: _mask
     - Name: $v
       Entry: 7
-      Data: 50|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 53|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: _mask
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 51|System.RuntimeType, mscorlib
+      Data: 54|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: System.Int32, mscorlib
@@ -788,7 +842,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 51
+      Data: 54
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -803,7 +857,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 52|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 55|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -827,16 +881,16 @@ MonoBehaviour:
       Data: MaxTargets
     - Name: $v
       Entry: 7
-      Data: 53|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 56|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: MaxTargets
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 51
+      Data: 54
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 51
+      Data: 54
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -851,7 +905,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 54|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 57|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0

--- a/Runtime/Udon/UdonAssets/ObjectToggle.asset
+++ b/Runtime/Udon/UdonAssets/ObjectToggle.asset
@@ -1,0 +1,809 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
+  m_Name: ObjectToggle
+  m_EditorClassIdentifier: 
+  serializedUdonProgramAsset: {fileID: 11400000, guid: f58e0eab97fe15040a7e428b0582b582,
+    type: 2}
+  udonAssembly: 
+  assemblyError: 
+  sourceCsScript: {fileID: 11500000, guid: 11bdc179b8c428040a1ed5731c0c4809, type: 3}
+  scriptVersion: 2
+  compiledVersion: 2
+  behaviourSyncMode: 4
+  hasInteractEvent: 0
+  scriptID: -5467277885404189942
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes:
+    - Name: fieldDefinitions
+      Entry: 7
+      Data: 0|System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[UdonSharp.Compiler.FieldDefinition,
+        UdonSharp.Editor]], mscorlib
+    - Name: comparer
+      Entry: 7
+      Data: 1|System.Collections.Generic.GenericEqualityComparer`1[[System.String,
+        mscorlib]], mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 12
+      Data: 13
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: button
+    - Name: $v
+      Entry: 7
+      Data: 2|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: button
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 3|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.Button, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 3
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 4|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 5|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: toggle
+    - Name: $v
+      Entry: 7
+      Data: 6|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: toggle
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 7|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.Toggle, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 7
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 8|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 9|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: toggleGroup
+    - Name: $v
+      Entry: 7
+      Data: 10|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: toggleGroup
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 11|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.ToggleGroup, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 11
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 12|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 13|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: slider
+    - Name: $v
+      Entry: 7
+      Data: 14|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: slider
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 15|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.Slider, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 15
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 16|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 17|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: scrollbar
+    - Name: $v
+      Entry: 7
+      Data: 18|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: scrollbar
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 19|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.Scrollbar, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 19
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 20|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 21|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: scrollRect
+    - Name: $v
+      Entry: 7
+      Data: 22|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: scrollRect
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 23|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.ScrollRect, UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 23
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 24|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 25|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: tmpDropdown
+    - Name: $v
+      Entry: 7
+      Data: 26|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: tmpDropdown
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 27|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: TMPro.TMP_Dropdown, Unity.TextMeshPro
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 27
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 28|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 29|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: tmpInputField
+    - Name: $v
+      Entry: 7
+      Data: 30|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: tmpInputField
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 31|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: TMPro.TMP_InputField, Unity.TextMeshPro
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 31
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 32|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 33|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _isGlobal
+    - Name: $v
+      Entry: 7
+      Data: 34|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _isGlobal
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 35|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Boolean, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 35
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 36|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 37|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _targets
+    - Name: $v
+      Entry: 7
+      Data: 38|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _targets
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 39|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.Transform[], UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 39
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 40|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 41|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _invertMask
+    - Name: $v
+      Entry: 7
+      Data: 42|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _invertMask
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 35
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 35
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 3
+      Data: 1
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 43|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 44|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _mask
+    - Name: $v
+      Entry: 7
+      Data: 45|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _mask
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 46|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Int32, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 46
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 47|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: MaxTargets
+    - Name: $v
+      Entry: 7
+      Data: 48|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: MaxTargets
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 46
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 46
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 49|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 

--- a/Runtime/Udon/UdonAssets/ObjectToggle.asset.meta
+++ b/Runtime/Udon/UdonAssets/ObjectToggle.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a2063847ddf64a3479a5bfb0ebdb713c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Udon/UdonAssets/ObjectToggleTrigger.asset
+++ b/Runtime/Udon/UdonAssets/ObjectToggleTrigger.asset
@@ -10,18 +10,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
-  m_Name: ObjectToggle
+  m_Name: ObjectToggleTrigger
   m_EditorClassIdentifier: 
-  serializedUdonProgramAsset: {fileID: 11400000, guid: f58e0eab97fe15040a7e428b0582b582,
+  serializedUdonProgramAsset: {fileID: 11400000, guid: 15fb534cd540a0a41911544e4c35181d,
     type: 2}
   udonAssembly: 
   assemblyError: 
-  sourceCsScript: {fileID: 11500000, guid: 11bdc179b8c428040a1ed5731c0c4809, type: 3}
+  sourceCsScript: {fileID: 11500000, guid: 5f3dda3760148dc42a17a4dfd84e7cab, type: 3}
   scriptVersion: 2
   compiledVersion: 2
   behaviourSyncMode: 4
   hasInteractEvent: 0
-  scriptID: -5467277885404189942
+  scriptID: 5930924833843119638
   serializationData:
     SerializedFormat: 2
     SerializedBytes: 
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 14
+      Data: 9
     - Name: 
       Entry: 7
       Data: 
@@ -530,148 +530,28 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _isGlobal
+      Data: _targetObjectToggle
     - Name: $v
       Entry: 7
       Data: 34|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _isGlobal
+      Data: _targetObjectToggle
     - Name: <UserType>k__BackingField
       Entry: 7
       Data: 35|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
-      Data: System.Boolean, mscorlib
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: <SystemType>k__BackingField
-      Entry: 9
-      Data: 35
-    - Name: <SyncMode>k__BackingField
-      Entry: 7
-      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
-    - Name: 
-      Entry: 6
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: <IsSerialized>k__BackingField
-      Entry: 5
-      Data: true
-    - Name: _fieldAttributes
-      Entry: 7
-      Data: 36|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
-    - Name: 
-      Entry: 12
-      Data: 1
-    - Name: 
-      Entry: 7
-      Data: 37|UnityEngine.SerializeField, UnityEngine.CoreModule
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 13
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 1
-      Data: _targets
-    - Name: $v
-      Entry: 7
-      Data: 38|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
-    - Name: <Name>k__BackingField
-      Entry: 1
-      Data: _targets
-    - Name: <UserType>k__BackingField
-      Entry: 7
-      Data: 39|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: UnityEngine.Transform[], UnityEngine.CoreModule
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: <SystemType>k__BackingField
-      Entry: 9
-      Data: 39
-    - Name: <SyncMode>k__BackingField
-      Entry: 7
-      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
-    - Name: 
-      Entry: 6
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: <IsSerialized>k__BackingField
-      Entry: 5
-      Data: true
-    - Name: _fieldAttributes
-      Entry: 7
-      Data: 40|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
-    - Name: 
-      Entry: 12
-      Data: 1
-    - Name: 
-      Entry: 7
-      Data: 41|UnityEngine.SerializeField, UnityEngine.CoreModule
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 13
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 1
-      Data: _linkedToggles
-    - Name: $v
-      Entry: 7
-      Data: 42|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
-    - Name: <Name>k__BackingField
-      Entry: 1
-      Data: _linkedToggles
-    - Name: <UserType>k__BackingField
-      Entry: 7
-      Data: 43|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: Limitex.MonoUI.Udon.ObjectToggleTrigger[], dev.limitex.mono-ui.udon
+      Data: Limitex.MonoUI.Udon.ObjectToggle, dev.limitex.mono-ui.udon
     - Name: 
       Entry: 8
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 7
-      Data: 44|System.RuntimeType, mscorlib
+      Data: 36|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
-      Data: UnityEngine.Component[], UnityEngine.CoreModule
+      Data: VRC.Udon.UdonBehaviour, VRC.Udon
     - Name: 
       Entry: 8
       Data: 
@@ -689,172 +569,16 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 45|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 37|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 46|UnityEngine.HideInInspector, UnityEngine.CoreModule
+      Data: 38|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
-    - Name: 
-      Entry: 13
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 1
-      Data: _invertMask
-    - Name: $v
-      Entry: 7
-      Data: 47|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
-    - Name: <Name>k__BackingField
-      Entry: 1
-      Data: _invertMask
-    - Name: <UserType>k__BackingField
-      Entry: 9
-      Data: 35
-    - Name: <SystemType>k__BackingField
-      Entry: 9
-      Data: 35
-    - Name: <SyncMode>k__BackingField
-      Entry: 7
-      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
-    - Name: 
-      Entry: 3
-      Data: 1
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: <IsSerialized>k__BackingField
-      Entry: 5
-      Data: false
-    - Name: _fieldAttributes
-      Entry: 7
-      Data: 48|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
-    - Name: 
-      Entry: 12
-      Data: 1
-    - Name: 
-      Entry: 7
-      Data: 49|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 13
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 1
-      Data: _mask
-    - Name: $v
-      Entry: 7
-      Data: 50|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
-    - Name: <Name>k__BackingField
-      Entry: 1
-      Data: _mask
-    - Name: <UserType>k__BackingField
-      Entry: 7
-      Data: 51|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: System.Int32, mscorlib
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: <SystemType>k__BackingField
-      Entry: 9
-      Data: 51
-    - Name: <SyncMode>k__BackingField
-      Entry: 7
-      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
-    - Name: 
-      Entry: 6
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: <IsSerialized>k__BackingField
-      Entry: 5
-      Data: false
-    - Name: _fieldAttributes
-      Entry: 7
-      Data: 52|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
-    - Name: 
-      Entry: 12
-      Data: 0
-    - Name: 
-      Entry: 13
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 1
-      Data: MaxTargets
-    - Name: $v
-      Entry: 7
-      Data: 53|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
-    - Name: <Name>k__BackingField
-      Entry: 1
-      Data: MaxTargets
-    - Name: <UserType>k__BackingField
-      Entry: 9
-      Data: 51
-    - Name: <SystemType>k__BackingField
-      Entry: 9
-      Data: 51
-    - Name: <SyncMode>k__BackingField
-      Entry: 7
-      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
-    - Name: 
-      Entry: 6
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: <IsSerialized>k__BackingField
-      Entry: 5
-      Data: false
-    - Name: _fieldAttributes
-      Entry: 7
-      Data: 54|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
-    - Name: 
-      Entry: 12
-      Data: 0
     - Name: 
       Entry: 13
       Data: 

--- a/Runtime/Udon/UdonAssets/ObjectToggleTrigger.asset.meta
+++ b/Runtime/Udon/UdonAssets/ObjectToggleTrigger.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 87c3c5ac1addfa643ba9c6e80eedee35
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Udon/UdonAssets/SwitchManager.asset
+++ b/Runtime/Udon/UdonAssets/SwitchManager.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   sourceCsScript: {fileID: 11500000, guid: 6c21d987a0572574aa4c7aa0aed730ae, type: 3}
   scriptVersion: 2
   compiledVersion: 2
-  behaviourSyncMode: 1
+  behaviourSyncMode: 4
   hasInteractEvent: 0
   scriptID: 3450544398086129762
   serializationData:

--- a/Runtime/Udon/UdonSharp/ObjectButton.cs
+++ b/Runtime/Udon/UdonSharp/ObjectButton.cs
@@ -112,7 +112,7 @@ namespace Limitex.MonoUI.Udon
             ApplyMaskToTargets();
         }
 
-        protected override void OnButtonClick(Button button)
+        public void TriggerAction()
         {
             if (!Networking.IsOwner(gameObject))
             {
@@ -141,6 +141,11 @@ namespace Limitex.MonoUI.Udon
             }
 
             RequestSerialization();
+        }
+
+        protected override void OnButtonClick(Button button)
+        {
+            TriggerAction();
         }
     }
 }

--- a/Runtime/Udon/UdonSharp/ObjectButton.cs
+++ b/Runtime/Udon/UdonSharp/ObjectButton.cs
@@ -17,6 +17,7 @@ namespace Limitex.MonoUI.Udon
     public class ObjectButton : MonoUIBehaviour
     {
         [SerializeField] private bool _isGlobal;
+        [SerializeField] private bool _defaultTargetState = true;
         [SerializeField] private ButtonType _buttonType = ButtonType.Invert;
         [SerializeField] private Transform[] _targets;
 
@@ -42,6 +43,7 @@ namespace Limitex.MonoUI.Udon
                 if (_targets[i] == null)
                 {
                     Debug.LogWarning($"Target at index {i} is null. Please assign a Transform.", this);
+                    SetMask(i, _defaultTargetState);
                     continue;
                 }
 

--- a/Runtime/Udon/UdonSharp/ObjectButton.cs
+++ b/Runtime/Udon/UdonSharp/ObjectButton.cs
@@ -41,7 +41,7 @@ namespace Limitex.MonoUI.Udon
             {
                 if (_targets[i] == null)
                 {
-                    Debug.LogError($"Target at index {i} is null. Please assign a Transform.", this);
+                    Debug.LogWarning($"Target at index {i} is null. Please assign a Transform.", this);
                     continue;
                 }
 
@@ -103,6 +103,12 @@ namespace Limitex.MonoUI.Udon
         {
             for (int i = 0; i < MaxTargets; i++)
             {
+                if (_targets[i] == null)
+                {
+                    Debug.LogWarning($"Target at index {i} is null. Please assign a Transform.", this);
+                    continue;
+                }
+
                 _targets[i].gameObject.SetActive(GetMask(i));
             }
         }

--- a/Runtime/Udon/UdonSharp/ObjectButton.cs
+++ b/Runtime/Udon/UdonSharp/ObjectButton.cs
@@ -71,10 +71,10 @@ namespace Limitex.MonoUI.Udon
             // Inverts all bits within the 'MaxTargets' range.
 
             // Create a mask consisting of 'MaxTargets' number of ones.
-            int inversionMask = (1 << MaxTargets) - 1;
+            int inversionMask = (1 << MaxTargets) - 1;
 
             // Use the XOR operator to flip every bit within the mask.
-            _mask ^= inversionMask;
+            _mask ^= inversionMask;
         }
 
 

--- a/Runtime/Udon/UdonSharp/ObjectButton.cs
+++ b/Runtime/Udon/UdonSharp/ObjectButton.cs
@@ -1,0 +1,147 @@
+﻿using UdonSharp;
+using UnityEngine;
+using UnityEngine.UI;
+using VRC.SDKBase;
+
+namespace Limitex.MonoUI.Udon
+{
+    enum ButtonType
+    {
+        Invert,
+        Shift,
+    }
+
+    [AddComponentMenu("Mono UI/MI Object Button")]
+    [RequireComponent(typeof(Button))]
+    [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
+    public class ObjectButton : MonoUIBehaviour
+    {
+        [SerializeField] private bool _isGlobal;
+        [SerializeField] private ButtonType _buttonType = ButtonType.Invert;
+        [SerializeField] private Transform[] _targets;
+
+        private const int MAX_MASK_SIZE = sizeof(int) * 8;
+
+        [UdonSynced(UdonSyncMode.None)] private int _mask = 0;
+
+        private int MaxTargets;
+
+        private void Start()
+        {
+            MaxTargets = Mathf.Min(_targets.Length, MAX_MASK_SIZE);
+
+            if (_targets.Length > MAX_MASK_SIZE)
+            {
+                Debug.LogWarning($"Total targets count {_targets.Length} " +
+                    $"exceeds maximum mask size of {MAX_MASK_SIZE}. " +
+                    $"Only the first {MAX_MASK_SIZE} will be processed.");
+            }
+
+            for (int i = 0; i < MaxTargets; i++)
+            {
+                if (_targets[i] == null)
+                {
+                    Debug.LogError($"Target at index {i} is null. Please assign a Transform.", this);
+                    continue;
+                }
+
+                SetMask(i, _targets[i].gameObject.activeSelf);
+            }
+        }
+
+        private void SetMask(int index, bool value)
+        {
+            if (value)
+            {
+                _mask |= (1 << index);
+            }
+            else
+            {
+                _mask &= ~(1 << index);
+            }
+        }
+
+        private bool GetMask(int index)
+        {
+            return (_mask & (1 << index)) != 0;
+        }
+
+        private void InvertMask()
+        {
+            // Inverts all bits within the 'MaxTargets' range.
+
+            // Create a mask consisting of 'MaxTargets' number of ones.
+            int inversionMask = (1 << MaxTargets) - 1;
+
+            // Use the XOR operator to flip every bit within the mask.
+            _mask ^= inversionMask;
+        }
+
+
+        private void ShiftMask()
+        {
+            // Performs a circular left shift (rotate left).
+
+            // Store the state of the most significant bit (MSB).
+            bool mostSignificantBit = (_mask & (1 << (MaxTargets - 1))) != 0;
+
+            // Shift the entire mask one bit to the left.
+            _mask <<= 1;
+
+            // If the original MSB was 1, wrap it around to the least significant bit (LSB).
+            if (mostSignificantBit)
+            {
+                _mask |= 1;
+            }
+
+            // Clear any bits outside the range of MaxTargets.
+            int sequenceMask = (1 << MaxTargets) - 1;
+            _mask &= sequenceMask;
+        }
+
+        private void ApplyMaskToTargets()
+        {
+            for (int i = 0; i < MaxTargets; i++)
+            {
+                _targets[i].gameObject.SetActive(GetMask(i));
+            }
+        }
+
+        public override void OnDeserialization()
+        {
+            ApplyMaskToTargets();
+        }
+
+        protected override void OnButtonClick(Button button)
+        {
+            if (!Networking.IsOwner(gameObject))
+            {
+                Networking.SetOwner(Networking.LocalPlayer, gameObject);
+            }
+
+            if (_buttonType == ButtonType.Invert)
+            {
+                InvertMask();
+            }
+            else if (_buttonType == ButtonType.Shift)
+            {
+                ShiftMask();
+            }
+            else
+            {
+                Debug.LogError($"Unknown button type: {_buttonType}");
+                return;
+            }
+
+            ApplyMaskToTargets();
+
+            if (!_isGlobal)
+            {
+                return;
+            }
+
+            RequestSerialization();
+        }
+    }
+}
+

--- a/Runtime/Udon/UdonSharp/ObjectButton.cs.meta
+++ b/Runtime/Udon/UdonSharp/ObjectButton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5bcc7fabf91247a48ab90924130bc16e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Udon/UdonSharp/ObjectButtonTrigger.cs
+++ b/Runtime/Udon/UdonSharp/ObjectButtonTrigger.cs
@@ -8,7 +8,9 @@ namespace Limitex.MonoUI.Udon
     [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
     public class ObjectButtonTrigger : MonoUIBehaviour
     {
-        [SerializeField] public ObjectButton _targetObjectButton;
+        [SerializeField] private ObjectButton _targetObjectButton;
+
+        public const string TargetObjectButtonName = nameof(_targetObjectButton);
 
         protected override void OnButtonClick(Button button)
         {

--- a/Runtime/Udon/UdonSharp/ObjectButtonTrigger.cs
+++ b/Runtime/Udon/UdonSharp/ObjectButtonTrigger.cs
@@ -8,7 +8,7 @@ namespace Limitex.MonoUI.Udon
     [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
     public class ObjectButtonTrigger : MonoUIBehaviour
     {
-        [SerializeField] private ObjectButton _targetObjectButton;
+        [SerializeField] public ObjectButton _targetObjectButton;
 
         protected override void OnButtonClick(Button button)
         {

--- a/Runtime/Udon/UdonSharp/ObjectButtonTrigger.cs
+++ b/Runtime/Udon/UdonSharp/ObjectButtonTrigger.cs
@@ -1,0 +1,24 @@
+﻿using UdonSharp;
+using UnityEngine;
+using UnityEngine.UI;
+namespace Limitex.MonoUI.Udon
+{
+    [AddComponentMenu("Mono UI/MI Object Button Trigger")]
+    [RequireComponent(typeof(Button))]
+    [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
+    public class ObjectButtonTrigger : MonoUIBehaviour
+    {
+        [SerializeField] private ObjectButton _targetObjectButton;
+
+        protected override void OnButtonClick(Button button)
+        {
+            if (_targetObjectButton == null)
+            {
+                Debug.LogError("Target ObjectButton is not assigned.", this);
+                return;
+            }
+
+            _targetObjectButton.TriggerAction();
+        }
+    }
+}

--- a/Runtime/Udon/UdonSharp/ObjectButtonTrigger.cs
+++ b/Runtime/Udon/UdonSharp/ObjectButtonTrigger.cs
@@ -1,6 +1,7 @@
 ﻿using UdonSharp;
 using UnityEngine;
 using UnityEngine.UI;
+
 namespace Limitex.MonoUI.Udon
 {
     [AddComponentMenu("Mono UI/MI Object Button Trigger")]

--- a/Runtime/Udon/UdonSharp/ObjectButtonTrigger.cs.meta
+++ b/Runtime/Udon/UdonSharp/ObjectButtonTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ed71b4437bf0ae488602f5ec5adcfc8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Udon/UdonSharp/ObjectToggle.cs
+++ b/Runtime/Udon/UdonSharp/ObjectToggle.cs
@@ -21,14 +21,16 @@ namespace Limitex.MonoUI.Udon
 
         private const int MAX_MASK_SIZE = sizeof(int) * 8;
 
-        [UdonSynced(UdonSyncMode.None)] private bool _invertMask;
+        [UdonSynced(UdonSyncMode.None)] private bool _invertMask = false;
 
         private int _mask = 0;
         private int MaxTargets;
+        private bool InitialToggleState;
 
         private void Start()
         {
             MaxTargets = Mathf.Min(_targets.Length, MAX_MASK_SIZE);
+            InitialToggleState = toggle.isOn;
 
             if (_targets.Length > MAX_MASK_SIZE)
             {
@@ -49,7 +51,6 @@ namespace Limitex.MonoUI.Udon
                 SetMask(i, _targets[i].gameObject.activeSelf);
             }
 
-            _invertMask = toggle.isOn;
             ApplyMaskToTargets();
         }
 
@@ -82,12 +83,14 @@ namespace Limitex.MonoUI.Udon
 
                 _targets[i].gameObject.SetActive(GetMask(i) ^ _invertMask);
             }
-            toggle.isOn = _invertMask;
+
+            bool currentToggleState = _invertMask ^ InitialToggleState;
+            toggle.isOn = currentToggleState;
 
             foreach (var linkedToggle in _linkedToggles)
             {
                 if (linkedToggle == null) continue;
-                linkedToggle.SetToggleState(_invertMask);
+                linkedToggle.SetToggleState(currentToggleState);
             }
         }
 
@@ -103,7 +106,7 @@ namespace Limitex.MonoUI.Udon
                 Networking.SetOwner(Networking.LocalPlayer, gameObject);
             }
 
-            _invertMask = isActive;
+            _invertMask = isActive ^ InitialToggleState;
 
             ApplyMaskToTargets();
 

--- a/Runtime/Udon/UdonSharp/ObjectToggle.cs
+++ b/Runtime/Udon/UdonSharp/ObjectToggle.cs
@@ -50,6 +50,7 @@ namespace Limitex.MonoUI.Udon
             }
 
             _invertMask = toggle.isOn;
+            ApplyMaskToTargets();
         }
 
         private void SetMask(int index, bool value)

--- a/Runtime/Udon/UdonSharp/ObjectToggle.cs
+++ b/Runtime/Udon/UdonSharp/ObjectToggle.cs
@@ -104,6 +104,11 @@ namespace Limitex.MonoUI.Udon
             RequestSerialization();
         }
 
+        public bool GetToggleState()
+        {
+            return toggle.isOn;
+        }
+
         protected override void OnToggleValueChanged(Toggle toggle)
         {
             TriggerAction(toggle.isOn);

--- a/Runtime/Udon/UdonSharp/ObjectToggle.cs
+++ b/Runtime/Udon/UdonSharp/ObjectToggle.cs
@@ -12,6 +12,7 @@ namespace Limitex.MonoUI.Udon
     public class ObjectToggle : MonoUIBehaviour
     {
         [SerializeField] private bool _isGlobal;
+        [SerializeField] private bool _defaultTargetState = true;
         [SerializeField] private Transform[] _targets;
 
         [HideInInspector] public ObjectToggleTrigger[] _linkedToggles;
@@ -41,6 +42,7 @@ namespace Limitex.MonoUI.Udon
                 if (_targets[i] == null)
                 {
                     Debug.LogWarning($"Target at index {i} is null. Please assign a Transform.", this);
+                    SetMask(i, _defaultTargetState);
                     continue;
                 }
 

--- a/Runtime/Udon/UdonSharp/ObjectToggle.cs
+++ b/Runtime/Udon/UdonSharp/ObjectToggle.cs
@@ -1,0 +1,104 @@
+﻿using UdonSharp;
+using UnityEngine;
+using UnityEngine.UI;
+using VRC.SDKBase;
+using VRC.Udon;
+
+namespace Limitex.MonoUI.Udon
+{
+    [AddComponentMenu("Mono UI/MI Object Toggle")]
+    [RequireComponent(typeof(Toggle))]
+    [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
+    public class ObjectToggle : MonoUIBehaviour
+    {
+        [SerializeField] private bool _isGlobal;
+        [SerializeField] private Transform[] _targets;
+
+        private const int MAX_MASK_SIZE = sizeof(int) * 8;
+
+        [UdonSynced(UdonSyncMode.None)] private bool _invertMask;
+
+        private int _mask = 0;
+        private int MaxTargets;
+
+        private void Start()
+        {
+            MaxTargets = Mathf.Min(_targets.Length, MAX_MASK_SIZE);
+
+            if (_targets.Length > MAX_MASK_SIZE)
+            {
+                Debug.LogWarning($"Total targets count {_targets.Length} " +
+                    $"exceeds maximum mask size of {MAX_MASK_SIZE}. " +
+                    $"Only the first {MAX_MASK_SIZE} will be processed.");
+            }
+
+            for (int i = 0; i < MaxTargets; i++)
+            {
+                if (_targets[i] == null)
+                {
+                    Debug.LogError($"Target at index {i} is null. Please assign a Transform.", this);
+                    continue;
+                }
+
+                SetMask(i, _targets[i].gameObject.activeSelf);
+            }
+
+            _invertMask = toggle.isOn;
+        }
+
+        private void SetMask(int index, bool value)
+        {
+            if (value)
+            {
+                _mask |= (1 << index);
+            }
+            else
+            {
+                _mask &= ~(1 << index);
+            }
+        }
+
+        private bool GetMask(int index)
+        {
+            return (_mask & (1 << index)) != 0;
+        }
+
+        private void ApplyMaskToTargets()
+        {
+            for (int i = 0; i < MaxTargets; i++)
+            {
+                _targets[i].gameObject.SetActive(GetMask(i) ^ _invertMask);
+            }
+            toggle.isOn = _invertMask;
+        }
+
+        public override void OnDeserialization()
+        {
+            ApplyMaskToTargets();
+        }
+
+        public void TriggerAction(bool isActive)
+        {
+            if (!Networking.IsOwner(gameObject))
+            {
+                Networking.SetOwner(Networking.LocalPlayer, gameObject);
+            }
+
+            _invertMask = isActive;
+
+            ApplyMaskToTargets();
+
+            if (!_isGlobal)
+            {
+                return;
+            }
+
+            RequestSerialization();
+        }
+
+        protected override void OnToggleValueChanged(Toggle toggle)
+        {
+            TriggerAction(toggle.isOn);
+        }
+    }
+}

--- a/Runtime/Udon/UdonSharp/ObjectToggle.cs
+++ b/Runtime/Udon/UdonSharp/ObjectToggle.cs
@@ -14,6 +14,8 @@ namespace Limitex.MonoUI.Udon
         [SerializeField] private bool _isGlobal;
         [SerializeField] private Transform[] _targets;
 
+        [HideInInspector] public ObjectToggleTrigger[] _linkedToggles;
+
         private const int MAX_MASK_SIZE = sizeof(int) * 8;
 
         [UdonSynced(UdonSyncMode.None)] private bool _invertMask;
@@ -70,6 +72,12 @@ namespace Limitex.MonoUI.Udon
                 _targets[i].gameObject.SetActive(GetMask(i) ^ _invertMask);
             }
             toggle.isOn = _invertMask;
+
+            foreach (var linkedToggle in _linkedToggles)
+            {
+                if (linkedToggle == null) continue;
+                linkedToggle.SetToggleState(_invertMask);
+            }
         }
 
         public override void OnDeserialization()

--- a/Runtime/Udon/UdonSharp/ObjectToggle.cs
+++ b/Runtime/Udon/UdonSharp/ObjectToggle.cs
@@ -40,7 +40,7 @@ namespace Limitex.MonoUI.Udon
             {
                 if (_targets[i] == null)
                 {
-                    Debug.LogError($"Target at index {i} is null. Please assign a Transform.", this);
+                    Debug.LogWarning($"Target at index {i} is null. Please assign a Transform.", this);
                     continue;
                 }
 
@@ -71,6 +71,12 @@ namespace Limitex.MonoUI.Udon
         {
             for (int i = 0; i < MaxTargets; i++)
             {
+                if (_targets[i] == null)
+                {
+                    Debug.LogWarning($"Target at index {i} is null. Please assign a Transform.", this);
+                    continue;
+                }
+
                 _targets[i].gameObject.SetActive(GetMask(i) ^ _invertMask);
             }
             toggle.isOn = _invertMask;

--- a/Runtime/Udon/UdonSharp/ObjectToggle.cs
+++ b/Runtime/Udon/UdonSharp/ObjectToggle.cs
@@ -16,6 +16,8 @@ namespace Limitex.MonoUI.Udon
 
         [HideInInspector] public ObjectToggleTrigger[] _linkedToggles;
 
+        public const string LinkedTogglesName = nameof(_linkedToggles);
+
         private const int MAX_MASK_SIZE = sizeof(int) * 8;
 
         [UdonSynced(UdonSyncMode.None)] private bool _invertMask;

--- a/Runtime/Udon/UdonSharp/ObjectToggle.cs.meta
+++ b/Runtime/Udon/UdonSharp/ObjectToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 11bdc179b8c428040a1ed5731c0c4809
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Udon/UdonSharp/ObjectToggleTrigger.cs
+++ b/Runtime/Udon/UdonSharp/ObjectToggleTrigger.cs
@@ -13,6 +13,17 @@ namespace Limitex.MonoUI.Udon
     {
         [SerializeField] public ObjectToggle _targetObjectToggle;
 
+        private void Start()
+        {
+            if (_targetObjectToggle == null)
+            {
+                Debug.LogError("Target ObjectToggle is not assigned.", this);
+                return;
+            }
+
+            SetToggleState(_targetObjectToggle.GetToggleState());
+        }
+
         public void SetToggleState(bool isActive)
         {
             toggle.isOn = isActive;

--- a/Runtime/Udon/UdonSharp/ObjectToggleTrigger.cs
+++ b/Runtime/Udon/UdonSharp/ObjectToggleTrigger.cs
@@ -1,0 +1,31 @@
+﻿using UdonSharp;
+using UnityEngine;
+using UnityEngine.UI;
+using VRC.SDKBase;
+using VRC.Udon;
+
+namespace Limitex.MonoUI.Udon
+{
+    [AddComponentMenu("Mono UI/MI Object Toggle Trigger")]
+    [RequireComponent(typeof(Toggle))]
+    [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
+    public class ObjectToggleTrigger : MonoUIBehaviour
+    {
+        [SerializeField] public ObjectToggle _targetObjectToggle;
+
+        public void SetToggleState(bool isActive)
+        {
+            toggle.isOn = isActive;
+        }
+
+        protected override void OnToggleValueChanged(Toggle toggle)
+        {
+            if (_targetObjectToggle == null)
+            {
+                Debug.LogError("Target ObjectToggle is not assigned.", this);
+                return;
+            }
+            _targetObjectToggle.TriggerAction(toggle.isOn);
+        }
+    }
+}

--- a/Runtime/Udon/UdonSharp/ObjectToggleTrigger.cs
+++ b/Runtime/Udon/UdonSharp/ObjectToggleTrigger.cs
@@ -11,7 +11,9 @@ namespace Limitex.MonoUI.Udon
     [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
     public class ObjectToggleTrigger : MonoUIBehaviour
     {
-        [SerializeField] public ObjectToggle _targetObjectToggle;
+        [SerializeField] private ObjectToggle _targetObjectToggle;
+
+        public const string TargetObjectToggleName = nameof(_targetObjectToggle);
 
         private void Start()
         {

--- a/Runtime/Udon/UdonSharp/ObjectToggleTrigger.cs.meta
+++ b/Runtime/Udon/UdonSharp/ObjectToggleTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f3dda3760148dc42a17a4dfd84e7cab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Udon/UdonSharp/SwitchManager.cs
+++ b/Runtime/Udon/UdonSharp/SwitchManager.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 namespace Limitex.MonoUI.Udon
 {
     [AddComponentMenu("")]
-    [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
+    [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
     public class SwitchManager : MonoUIBehaviour
     {
         [SerializeField] private Animator animator;


### PR DESCRIPTION
This pull request introduces a powerful and flexible new system for managing GameObject states: `ObjectButton` and `ObjectToggle`. These UdonSharp components are designed to provide an efficient and user-friendly way to control the visibility of multiple objects in a scene, with support for both local and global synchronization.

This resolves the need for a standardized, reusable, and optimized solution for common object interaction patterns in VRChat worlds.

### Key Features & Implementation Details

####  `ObjectButton`
- **State Management**: Manages the active state of an array of `Transform` targets using an efficient integer bitmask. This supports up to 32 objects per button.
- **Button Types**:
    - `Invert`: Flips the active state of all target objects.
    - `Shift`: Performs a circular left shift on the state mask, creating cycling patterns.
- **Synchronization**: Includes an `_isGlobal` flag to enable network synchronization of object states, making it suitable for multi-user environments.
- **Decoupled Trigger**: `ObjectButtonTrigger` allows any UI Button to trigger the `ObjectButton`'s action, promoting flexible UI design.

####  `ObjectToggle`
- **Persistent Toggling**: Toggles the active state of target objects based on the UI Toggle's `isOn` property. It intelligently handles the initial state of objects.
- **Synchronization**: Like the ObjectButton, it supports an `_isGlobal` option for synchronized behavior across clients.
- **Automatic Linking**: Comes with `ObjectToggleTrigger` components that can be placed on other UI Toggles. These triggers are automatically linked to the main `ObjectToggle` at build time.

### Editor Enhancements (Developer Experience)

To significantly improve the workflow for world creators, this PR introduces two key editor features:

1.  **`ObjectToggleBuildProcessor`**:
    - A scene processor that runs during the build process.
    - It automatically finds all `ObjectToggleTrigger` instances in the scene and links them to their corresponding `ObjectToggle` master component.
    - This completely automates the `_linkedToggles` array population, saving significant setup time and eliminating a common point of error.

2.  **`ReferencedByDrawer` Utility**:
    - A new custom inspector utility that adds a **"Referenced By (Detected in Scene)"** foldout to the `ObjectButton` and `ObjectToggle` components.
    - This feature scans the scene and displays a list of all trigger components that are referencing the selected object.
    - It provides immediate, clear feedback on scene setup and makes debugging connections much easier.

These new components and editor scripts create a robust and easy-to-use system for interactive objects, streamlining the development process for world creators.

### Issues

close #47 
close #48 